### PR TITLE
fix: per-event-type field registry and integer weights validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,14 @@
 `dblstreamgen` is a Spark/Databricks library for generating synthetic streaming data using `dbldatagen`. It supports multiple event types, weighted rate distribution, and streaming to various sinks (Kinesis, Kafka, Event Hubs, Delta).
 
 **Key Features:**
-- **Config-driven** - Define schemas in YAML
+- **Config-driven** - Define schemas in YAML with no code required
 - **dbldatagen-powered** - Leverages Spark for scale
 - **Multiple event types** - Wide schema approach for 1500+ types
-- **Flexible sinks** - Kinesis, Kafka, Event Hubs, Delta (planned)
+- **Flexible sinks** - Kinesis, Kafka, Event Hubs, Delta
 - **Use-case agnostic** - Works for any domain
+- **Data quality testing** - Outlier injection and null injection for testing pipelines
+- **Derived fields** - Computed columns that reference other generated fields
+- **Nested structs** - Complex nested types assembled automatically from config
 
 ---
 
@@ -69,7 +72,7 @@ make build              # Build wheel
 make release-patch      # Full release workflow
 ```
 
-**Output:** `dist/dblstreamgen-0.1.0-py3-none-any.whl`
+**Output:** `dist/dblstreamgen-0.2.0-py3-none-any.whl`
 
 For detailed build instructions, tool comparisons, publishing to PyPI, and CI/CD integration, see [BUILD.md](BUILD.md).
 
@@ -84,14 +87,14 @@ For detailed build instructions, tool comparisons, publishing to PyPI, and CI/CD
 CREATE VOLUME IF NOT EXISTS catalog.schema.libraries;
 
 # Upload the wheel using Databricks UI or CLI
-# File location: /Volumes/catalog/schema/libraries/dblstreamgen-0.1.0-py3-none-any.whl
+# File location: /Volumes/catalog/schema/libraries/dblstreamgen-0.2.0-py3-none-any.whl
 ```
 
 #### Step 2: Install in Notebook
 
 ```python
 # Install the library
-%pip install /Volumes/catalog/schema/libraries/dblstreamgen-0.1.0-py3-none-any.whl
+%pip install /Volumes/catalog/schema/libraries/dblstreamgen-0.2.0-py3-none-any.whl
 
 # Restart Python to load the library
 dbutils.library.restartPython()
@@ -120,7 +123,7 @@ Copy these cells into a Databricks notebook or see the complete example at `samp
 **Cell 1 - Install:**
 ```python
 # Install from Unity Catalog volume
-%pip install /Volumes/catalog/schema/libraries/dblstreamgen-0.1.0-py3-none-any.whl
+%pip install /Volumes/catalog/schema/libraries/dblstreamgen-0.2.0-py3-none-any.whl
 dbutils.library.restartPython()
 ```
 
@@ -664,7 +667,7 @@ For scale testing with 1500+ event types, see `sample/configs/1500_events_config
 
 ```python
 # Make sure the wheel is installed
-%pip install /Volumes/catalog/schema/libraries/dblstreamgen-0.1.0-py3-none-any.whl
+%pip install /Volumes/catalog/schema/libraries/dblstreamgen-0.2.0-py3-none-any.whl
 
 # Restart Python
 dbutils.library.restartPython()
@@ -797,6 +800,15 @@ sink_config:
 - **Simple Types**: uuid, string, int, long, short, byte, float, double, decimal, boolean, timestamp, date, binary
 - **Complex Types**: array, struct, map (with nesting support)
 
+### v0.2.0 Features
+- **Outlier Injection**: Configure bad data percentages per field for data quality testing
+- **Raw `expr` Passthrough**: Use arbitrary SQL expressions for field generation
+- **Derived Fields**: Computed columns referencing other generated columns
+- **Weighted Distribution Fix**: Correct probability sampling for multi-value fields
+- **Integer Weights**: Event type weights accept integers (e.g., `[6, 3, 1]`), auto-normalized
+
+See `docs/TYPE_SYSTEM.md` for complete v0.2.0 documentation.
+
 
 ---
 
@@ -820,4 +832,4 @@ This library is licensed under the Databricks License and is intended for use in
 
 ---
 
-*dblstreamgen v0.1.0 - Synthetic streaming data generation for Databricks*
+*dblstreamgen v0.2.0 - Synthetic streaming & batch data generation for Databricks*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dblstreamgen"
-version = "0.1.0"
+version = "0.2.0"
 description = "Databricks stream data generation for harness testing and performance validation"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/dblstreamgen/__init__.py
+++ b/src/dblstreamgen/__init__.py
@@ -1,6 +1,6 @@
 """dblstreamgen - Generate synthetic streaming data at scale for Databricks."""
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 
 from dblstreamgen.config import load_config, Config, ConfigurationError
 from dblstreamgen.orchestrator import StreamOrchestrator

--- a/src/dblstreamgen/config.py
+++ b/src/dblstreamgen/config.py
@@ -85,6 +85,18 @@ class Config:
         if 'type' not in sink_config:
             raise ConfigurationError("sink_config.type is required")
         
+        # Validate derived_fields (if present)
+        derived_fields = self.data.get('derived_fields', {})
+        for field_name, field_spec in derived_fields.items():
+            if 'expr' not in field_spec:
+                raise ConfigurationError(
+                    f"derived_fields.{field_name} must specify 'expr'"
+                )
+            if 'type' not in field_spec:
+                raise ConfigurationError(
+                    f"derived_fields.{field_name} must specify 'type'"
+                )
+        
         # Validate supported field types
         self._validate_field_types()
         


### PR DESCRIPTION
## Summary

- **Fixed multi-event-type field registry bug**: The `_build_field_registry` method was merging field specs across event types into a single dict, meaning only the first event type's values were used for shared fields. Now each event type stores its own spec independently, enabling different values/ranges per event type (e.g., `error_type = 'FATAL'` for crashes vs `'NON_FATAL'` for non-fatals).

- **Changed weight validation to positive integers**: Event type weights now must be positive integers (e.g., `[6, 3, 1]` for 60%/30%/10%) instead of floats summing to 1.0. This is more intuitive and avoids floating-point precision issues. Also added validation for `common_fields` weights.

- **Internal discriminator column**: Renamed the event type discriminator field to `_event_type_id` (underscore prefix) so it's treated as an internal column. Internal columns are automatically stripped from the output DataFrame in wide-schema mode (`serialize=False`), preventing internal bookkeeping fields from leaking into final output.

## Files Changed

| File | Change |
|------|--------|
| `src/dblstreamgen/config.py` | Integer weight validation + common_fields weight validation |
| `src/dblstreamgen/orchestrator/stream_orchestrator.py` | Per-event-type field registry, per-event-type CASE expressions, internal column stripping |

## Test plan

- [ ] Verify multi-event-type configs generate distinct values per event type
- [ ] Verify integer weights (e.g., `[6, 3, 1]`) produce correct distribution ratios
- [ ] Verify `_event_type_id` column is NOT present in output when `serialize=False`
- [ ] Verify complex types (struct, array, map) still work with the new registry structure
- [ ] Verify backward compatibility with single-event-type configs


Made with [Cursor](https://cursor.com)